### PR TITLE
feat: set correct this type type on SfdxResult.display

### DIFF
--- a/packages/command/src/exported.ts
+++ b/packages/command/src/exported.ts
@@ -6,10 +6,10 @@
  */
 
 import * as core from '@salesforce/core';
-import { SfdxCommand, SfdxResult } from './sfdxCommand';
+import { Result, SfdxCommand, SfdxResult } from './sfdxCommand';
 import { flags, FlagsConfig } from './sfdxFlags';
 import { TableOptions, UX } from './ux';
 
 core.Messages.importMessagesDirectory(__dirname);
 
-export { SfdxCommand, SfdxResult, FlagsConfig, core, flags, TableOptions, UX };
+export { Result, SfdxCommand, SfdxResult, FlagsConfig, core, flags, TableOptions, UX };

--- a/packages/command/src/sfdxCommand.ts
+++ b/packages/command/src/sfdxCommand.ts
@@ -18,7 +18,7 @@ Messages.importMessagesDirectory(__dirname);
 export interface SfdxResult {
   data?: AnyJson;
   tableColumnData?: TableOptions;
-  display?: (this: SfdxResult) => void;
+  display?: (this: Result) => void;
 }
 
 /**


### PR DESCRIPTION
@W-5206099@

Marked with `feat` as this is an API change, though it _is_ backward compatible so should only require a minor semver bump.
