### PR TITLE
feat: support deprecation and legacy flag props

### DIFF
--- a/packages/command/src/sfdxFlags.ts
+++ b/packages/command/src/sfdxFlags.ts
@@ -35,24 +35,26 @@ function option<T>(
 
 export namespace flags {
   export type Array<T> = Option<T[]> & { delimiter?: string; map?: (val: string) => T };
-  export type Any<T> = Partial<OclifFlags.IFlag<T>> & Describable;
+  export type Any<T> = Partial<OclifFlags.IFlag<T>> & SfdxProperties;
   export type BaseBoolean<T> = Partial<IBooleanFlag<T>>;
-  export type Boolean<T> = BaseBoolean<T> & Describable;
-  export type Builtin = { type: 'builtin'; description?: string; longDescription?: string };
+  export type Boolean<T> = BaseBoolean<T> & SfdxProperties;
+  export type Builtin = { type: 'builtin' } & Partial<Describable>;
   export type DateTime = Option<Date>;
+  export type Deprecatable = { deprecated?: { message: string; version: string } };
   export type Describable = { description: string; longDescription?: string };
   export type Discriminant = { kind: Kind };
   export type Discriminated<T> = T & Discriminant;
-  export type Milliseconds = Option<Duration> & NumericBounds;
-  export type Minutes = Option<Duration> & NumericBounds;
-  export type Enum<T> = EnumFlagOptions<T> & Describable;
+  export type Enum<T> = EnumFlagOptions<T> & SfdxProperties;
   export type Kind = keyof typeof flags;
   export type Input<T extends Parser.flags.Output> = OclifFlags.Input<T>;
+  export type Milliseconds = Option<Duration> & NumericBounds;
+  export type Minutes = Option<Duration> & NumericBounds;
   export type Number = Option<number> & NumericBounds;
   export type NumericBounds = { min?: number; max?: number };
-  export type Option<T> = Partial<IOptionFlag<Optional<T>>> & Describable;
+  export type Option<T> = Partial<IOptionFlag<Optional<T>>> & SfdxProperties;
   export type Output = OclifFlags.Output;
   export type Seconds = Option<Duration> & NumericBounds;
+  export type SfdxProperties = Describable & Deprecatable;
   export type String = Option<string>;
   export type Url = Option<URL>;
 }
@@ -355,52 +357,73 @@ const requiredBuiltinFlags = {
 
 const optionalBuiltinFlags = {
   apiversion(opts?: flags.Builtin): flags.Discriminated<flags.String> {
-    const flag = flags.string({
-      description: resolve(opts, 'description', messages.getMessage('apiversionFlagDescription')),
-      longDescription: resolve(opts, 'longDescription', messages.getMessage('apiversionFlagLongDescription')),
-      parse: (val: string) => {
-        if (sfdc.validateApiVersion(val)) return val;
-        throw SfdxError.create('@salesforce/command', 'flags', 'InvalidApiVersionError', [val]);
-      }
-    });
-    return flag;
+    return Object.assign(
+      opts || {},
+      flags.string({
+        description: resolve(opts, 'description', messages.getMessage('apiversionFlagDescription')),
+        longDescription: resolve(opts, 'longDescription', messages.getMessage('apiversionFlagLongDescription')),
+        parse: (val: string) => {
+          if (sfdc.validateApiVersion(val)) return val;
+          throw SfdxError.create('@salesforce/command', 'flags', 'InvalidApiVersionError', [val]);
+        }
+      })
+    );
   },
 
   concise(opts?: flags.Builtin): flags.Discriminated<flags.Boolean<boolean>> {
-    return flags.boolean({
-      description: resolve(opts, 'description', messages.getMessage('conciseFlagDescription')),
-      longDescription: resolve(opts, 'longDescription', messages.getMessage('conciseFlagLongDescription'))
-    });
+    return Object.assign(
+      opts || {},
+      flags.boolean({
+        description: resolve(opts, 'description', messages.getMessage('conciseFlagDescription')),
+        longDescription: resolve(opts, 'longDescription', messages.getMessage('conciseFlagLongDescription'))
+      })
+    );
   },
 
   quiet(opts?: flags.Builtin): flags.Discriminated<flags.Boolean<boolean>> {
-    return flags.boolean({
-      description: resolve(opts, 'description', messages.getMessage('quietFlagDescription')),
-      longDescription: resolve(opts, 'longDescription', messages.getMessage('quietFlagLongDescription'))
-    });
+    return Object.assign(
+      opts || {},
+      flags.boolean({
+        description: resolve(opts, 'description', messages.getMessage('quietFlagDescription')),
+        longDescription: resolve(opts, 'longDescription', messages.getMessage('quietFlagLongDescription'))
+      })
+    );
   },
 
   targetdevhubusername(opts?: flags.Builtin): flags.Discriminated<flags.String> {
-    return flags.string({
-      char: 'v',
-      description: resolve(opts, 'description', messages.getMessage('targetdevhubusernameFlagDescription')),
-      longDescription: resolve(opts, 'longDescription', messages.getMessage('targetdevhubusernameFlagLongDescription'))
-    });
+    return Object.assign(
+      opts || {},
+      flags.string({
+        char: 'v',
+        description: resolve(opts, 'description', messages.getMessage('targetdevhubusernameFlagDescription')),
+        longDescription: resolve(
+          opts,
+          'longDescription',
+          messages.getMessage('targetdevhubusernameFlagLongDescription')
+        )
+      })
+    );
   },
 
   targetusername(opts?: flags.Builtin): flags.Discriminated<flags.String> {
-    return flags.string({
-      char: 'u',
-      description: resolve(opts, 'description', messages.getMessage('targetusernameFlagDescription')),
-      longDescription: resolve(opts, 'longDescription', messages.getMessage('targetusernameFlagLongDescription'))
-    });
+    return Object.assign(
+      opts || {},
+      flags.string({
+        char: 'u',
+        description: resolve(opts, 'description', messages.getMessage('targetusernameFlagDescription')),
+        longDescription: resolve(opts, 'longDescription', messages.getMessage('targetusernameFlagLongDescription'))
+      })
+    );
   },
 
   verbose(opts?: flags.Builtin): flags.Discriminated<flags.Boolean<boolean>> {
-    return flags.boolean({
-      description: resolve(opts, 'description', messages.getMessage('verboseFlagDescription')),
-      longDescription: resolve(opts, 'longDescription', messages.getMessage('verboseFlagLongDescription'))
-    });
+    return Object.assign(
+      opts || {},
+      flags.boolean({
+        description: resolve(opts, 'description', messages.getMessage('verboseFlagDescription')),
+        longDescription: resolve(opts, 'longDescription', messages.getMessage('verboseFlagLongDescription'))
+      })
+    );
   }
 };
 

--- a/packages/command/test/unit/sfdxFlags.test.ts
+++ b/packages/command/test/unit/sfdxFlags.test.ts
@@ -49,6 +49,18 @@ describe('SfdxFlags', () => {
       expect(rv.apiversion).to.have.property('description', messages.getMessage('apiversionFlagDescription'));
     });
 
+    it('should carry forward additional properties on builtins when forced (for legacy toolbelt compatibility)', () => {
+      const rv = buildSfdxFlags(
+        {
+          // @ts-ignore force setting the char to simulate a legacy toolbelt use case
+          apiversion: flags.builtin({ char: 'a' })
+        },
+        {}
+      );
+      expect(rv.apiversion).to.have.property('description', messages.getMessage('apiversionFlagDescription'));
+      expect(rv.apiversion).to.have.property('char', 'a');
+    });
+
     it('should add builtin flags', () => {
       const rv = buildSfdxFlags(
         {
@@ -179,7 +191,7 @@ describe('SfdxFlags', () => {
     });
   });
 
-  describe('flags', () => {
+  describe('usage', () => {
     it('should echo back any builtin flag options', () => {
       const rv = flags.builtin();
       expect(rv).to.deep.equal({ type: 'builtin' });
@@ -193,6 +205,11 @@ describe('SfdxFlags', () => {
     it('should allow desc and long desc builtin flag options', () => {
       const rv = flags.builtin({ description: 'desc', longDescription: 'long desc' });
       expect(rv).to.deep.equal({ description: 'desc', longDescription: 'long desc', type: 'builtin' });
+    });
+
+    it('should support adding deprecation information', () => {
+      const rv = flags.string({ description: 'any flag', deprecated: { message: 'do not use', version: '41.0' } });
+      expect(rv.deprecated).to.deep.equal({ message: 'do not use', version: '41.0' });
     });
   });
 });


### PR DESCRIPTION
Needed for the toolbelt migration to oclif.  Adds support for retaining deprecation properties on flags, as well as carrying forward legacy properties.  The legacy case is specifically needed for one snowflake in toolbelt that attempts to set `-a` as a short flag for the `apiversion` builtin.  This PR honors additional properties set for builtin definitions that are not part of the `Builtin` flag type.  On the toolbelt side, we'll force the compiler to accept the `char` property on the `flags.builtin({...})` options at the call site. 