### PR TITLE
feat: allow duration bounds to accept duration

### DIFF
--- a/packages/command/src/sfdxFlags.ts
+++ b/packages/command/src/sfdxFlags.ts
@@ -167,7 +167,7 @@ function buildMilliseconds(options: flags.Milliseconds): flags.Discriminated<fla
   return option(kind, options, (val: string) => {
     const parsed = toNumber(val);
     validateValue(Number.isInteger(parsed), val, kind);
-    return Duration.milliseconds(validateBounds(kind, parsed, options, durationExtractor(kind)));
+    return Duration.milliseconds(validateBounds(kind, parsed, options, v => (isNumber(v) ? v : v[kind])));
   });
 }
 
@@ -176,7 +176,7 @@ function buildMinutes(options: flags.Minutes): flags.Discriminated<flags.Minutes
   return option(kind, options, (val: string) => {
     const parsed = toNumber(val);
     validateValue(Number.isInteger(parsed), val, kind);
-    return Duration.minutes(validateBounds(kind, parsed, options, durationExtractor(kind)));
+    return Duration.minutes(validateBounds(kind, parsed, options, v => (isNumber(v) ? v : v[kind])));
   });
 }
 
@@ -194,7 +194,7 @@ function buildSeconds(options: flags.Seconds): flags.Discriminated<flags.Seconds
   return option(kind, options, (val: string) => {
     const parsed = toNumber(val);
     validateValue(Number.isInteger(parsed), val, kind);
-    return Duration.seconds(validateBounds(kind, parsed, options, durationExtractor(kind)));
+    return Duration.seconds(validateBounds(kind, parsed, options, v => (isNumber(v) ? v : v[kind])));
   });
 }
 
@@ -211,10 +211,6 @@ function buildUrl(options: flags.Url): flags.Discriminated<flags.Url> {
 
 function buildBuiltin(options: Partial<flags.Builtin> = {}): flags.Builtin {
   return { ...options, type: 'builtin' };
-}
-
-function durationExtractor(prop: keyof Duration): (t: Duration | number) => number {
-  return v => (isNumber(v) ? v : v[prop]);
 }
 
 export const flags = {

--- a/packages/command/test/unit/sfdxFlags.test.ts
+++ b/packages/command/test/unit/sfdxFlags.test.ts
@@ -129,10 +129,7 @@ describe('SfdxFlags', () => {
 
     it('should throw for numeric flags with values out of bounds', () => {
       const integer = flags.integer({ description: 'integer', min: 2, max: 4 });
-      const milliseconds = flags.milliseconds({ description: 'milliseconds', min: 2, max: 4 });
-      const minutes = flags.minutes({ description: 'minutes', min: 2, max: 4 });
       const number = flags.number({ description: 'number', min: 2, max: 4 });
-      const seconds = flags.seconds({ description: 'seconds', min: 2, max: 4 });
 
       if (!hasFunction(integer, 'parse')) throw new Error('missing parse method for integer');
       expect(integer.parse('3')).to.equal(3);
@@ -141,6 +138,18 @@ describe('SfdxFlags', () => {
         'Expected integer greater than or equal to 2 but received 1'
       );
       expect(() => integer.parse('5')).to.throw(SfdxError, 'Expected integer less than or equal to 4 but received 5');
+
+      if (!hasFunction(number, 'parse')) throw new Error('missing parse method for number');
+      expect(number.parse('2.5')).to.equal(2.5);
+      expect(() => number.parse('1.5')).to.throw(
+        SfdxError,
+        'Expected number greater than or equal to 2 but received 1.5'
+      );
+      expect(() => number.parse('4.5')).to.throw(SfdxError, 'Expected number less than or equal to 4 but received 4.5');
+
+      const milliseconds = flags.milliseconds({ description: 'milliseconds', min: 2, max: 4 });
+      const minutes = flags.minutes({ description: 'minutes', min: 2, max: 4 });
+      const seconds = flags.seconds({ description: 'seconds', min: 2, max: 4 });
 
       if (!hasFunction(milliseconds, 'parse')) throw new Error('missing parse method for milliseconds');
       expect(milliseconds.parse('2')).to.deep.equal(Duration.milliseconds(2));
@@ -161,14 +170,6 @@ describe('SfdxFlags', () => {
       );
       expect(() => minutes.parse('5')).to.throw(SfdxError, 'Expected minutes less than or equal to 4 but received 5');
 
-      if (!hasFunction(number, 'parse')) throw new Error('missing parse method for number');
-      expect(number.parse('2.5')).to.equal(2.5);
-      expect(() => number.parse('1.5')).to.throw(
-        SfdxError,
-        'Expected number greater than or equal to 2 but received 1.5'
-      );
-      expect(() => number.parse('4.5')).to.throw(SfdxError, 'Expected number less than or equal to 4 but received 4.5');
-
       if (!hasFunction(seconds, 'parse')) throw new Error('missing parse method for seconds');
       expect(seconds.parse('3')).to.deep.equal(Duration.seconds(3));
       expect(() => seconds.parse('1')).to.throw(
@@ -176,6 +177,41 @@ describe('SfdxFlags', () => {
         'Expected seconds greater than or equal to 2 but received 1'
       );
       expect(() => seconds.parse('5')).to.throw(SfdxError, 'Expected seconds less than or equal to 4 but received 5');
+
+      const milliseconds2 = flags.milliseconds({
+        description: 'milliseconds',
+        min: Duration.milliseconds(2),
+        max: Duration.milliseconds(4)
+      });
+      const minutes2 = flags.minutes({ description: 'minutes', min: Duration.minutes(2), max: Duration.minutes(4) });
+      const seconds2 = flags.seconds({ description: 'seconds', min: Duration.seconds(2), max: Duration.seconds(4) });
+
+      if (!hasFunction(milliseconds2, 'parse')) throw new Error('missing parse method for milliseconds');
+      expect(milliseconds2.parse('2')).to.deep.equal(Duration.milliseconds(2));
+      expect(() => milliseconds2.parse('1')).to.throw(
+        SfdxError,
+        'Expected milliseconds greater than or equal to 2 but received 1'
+      );
+      expect(() => milliseconds2.parse('5')).to.throw(
+        SfdxError,
+        'Expected milliseconds less than or equal to 4 but received 5'
+      );
+
+      if (!hasFunction(minutes2, 'parse')) throw new Error('missing parse method for minutes');
+      expect(minutes2.parse('4')).to.deep.equal(Duration.minutes(4));
+      expect(() => minutes2.parse('1')).to.throw(
+        SfdxError,
+        'Expected minutes greater than or equal to 2 but received 1'
+      );
+      expect(() => minutes2.parse('5')).to.throw(SfdxError, 'Expected minutes less than or equal to 4 but received 5');
+
+      if (!hasFunction(seconds2, 'parse')) throw new Error('missing parse method for seconds');
+      expect(seconds2.parse('3')).to.deep.equal(Duration.seconds(3));
+      expect(() => seconds2.parse('1')).to.throw(
+        SfdxError,
+        'Expected seconds greater than or equal to 2 but received 1'
+      );
+      expect(() => seconds2.parse('5')).to.throw(SfdxError, 'Expected seconds less than or equal to 4 but received 5');
     });
   });
 


### PR DESCRIPTION
Allows `min` and `max` bounds for `Duration` flag types to accept `Duration` in addition to `number` (previously only `number` was accepted).  This is to be consistent with oclif's `default` field which is of type `T` for a flag of type `Option<T>`.  I would have preferred to remove `number` as a valid `min` or `max` value type for `Duration`s but that would have been an API breaking change.

I noticed this inconsistency while working on the oclif toolbelt command conversions.