### PR TITLE
feat: declarative flag validations

### DIFF
--- a/packages/command/messages/flags.json
+++ b/packages/command/messages/flags.json
@@ -23,6 +23,7 @@
   "MissingOrInvalidFlagDescription": "The flag %s is missing the description attribute, or the description is not a string.",
   "InvalidFlagChar": "The flag %s's char attribute must be one alphabetical character long.",
   "InvalidFlagName": "The flag %s's name must be a lowercase string that may contain numbers and hyphens.",
+  "FormattingMessageArrayValue": "Must only contain valid values.",
   "FormattingMessageArrayOption": "Must only contain values in [%s].",
   "FormattingMessageDate": "Must be parsable by the Javascript Date object.",
   "FormattingMessageId": "Must be a 15- or 18-char string in the format \"00Dxxxxxxxxxxxx\", where \"00D\" is a valid sObject prefix.",


### PR DESCRIPTION
Pete has been asking for declarative validations in flagsConfig entries.  This is the result of some tinkering I did last night to see if we could do it it nicely in the current implementation.  It seems to have worked out fairly well.  Any and all opinions welcome.

The API addition implemented here is to allow a new property on flags of the following form:

```
validate?: string | RegExp | ((val: string) => boolean)
```

When a `string` is used, a `RegExp` it gets converted to an instance of `RegExp`.

@peternhale Can you try out the branch and see if it meets your needs?