### PR TITLE
feat: allow massaging of result object printing by command

### DIFF
--- a/packages/command/src/sfdxCommand.ts
+++ b/packages/command/src/sfdxCommand.ts
@@ -355,13 +355,11 @@ export abstract class SfdxCommand extends Command {
 
     process.exitCode = process.exitCode || error.exitCode || 1;
 
-    const userDisplayError = {
+    const userDisplayError = Object.assign(this.getJsonResultObject(error.data, error.exitCode), {
       ...error.toObject(),
       stack: error.stack,
-      status: error.exitCode,
-      result: error.data,
       warnings: UX.warnings
-    };
+    });
 
     if (this.isJson) {
       // This should default to true, which will require a major version bump.
@@ -389,14 +387,15 @@ export abstract class SfdxCommand extends Command {
     // Only handle success since we're handling errors in the catch
     if (!err) {
       if (this.isJson) {
-        this.ux.logJson({
-          status: process.exitCode || 0,
-          result: this.result.data
-        });
+        this.ux.logJson(this.getJsonResultObject());
       } else {
         this.result.display();
       }
     }
+  }
+
+  protected getJsonResultObject(result = this.result.data, status = process.exitCode || 0) {
+    return { status, result };
   }
 
   protected parseVarargs(args: string[] = []): JsonMap {

--- a/packages/command/test/unit/sfdxCommand.test.ts
+++ b/packages/command/test/unit/sfdxCommand.test.ts
@@ -483,6 +483,26 @@ describe('SfdxCommand', () => {
     verifyUXOutput({ logJson: [{ status: 0, result: TestCommand.output }] });
   });
 
+  it('should allow adding information to the returned object for --json', async () => {
+    // Run the command
+    class TestCommand extends BaseTestCommand {
+      protected getJsonResultObject(result: AnyJson, status: number) {
+        return Object.assign(super.getJsonResultObject(result, status), {
+          myData: 'test'
+        });
+      }
+    }
+    const output = await TestCommand.run(['--json']);
+
+    expect(output).to.equal(TestCommand.output);
+    const expectedResult = {
+      data: TestCommand.output,
+      tableColumnData: undefined
+    };
+    expect(testCommandMeta.cmdInstance['result']).to.include(expectedResult);
+    verifyUXOutput({ logJson: [{ status: 0, result: TestCommand.output, myData: 'test' }] });
+  });
+
   it('should set the logLevel on the SfdxCommand logger with the --loglevel flag', async () => {
     // Run the command
     class TestCommand extends BaseTestCommand {}


### PR DESCRIPTION
API perf metrics are added to the result object, which seems like the right place to put them. We need to allow extending commands to add to the result object.