### PR TITLE
fix: 🐛 Support new AuthInfo changes in core

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -35,7 +35,7 @@
     "@oclif/parser": "^3.6.0",
     "@oclif/plugin-help": "^2.1.0",
     "@oclif/test": "^1.2.0",
-    "@salesforce/core": "^1.2.3",
+    "@salesforce/core": "^2.0.0",
     "@salesforce/kit": "^1.1.0",
     "@salesforce/ts-types": "^1.0.0",
     "chalk": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,10 +1034,10 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@salesforce/core@^1.2.3":
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/@salesforce/core/-/core-1.3.3.tgz#edd69a1534fad82a7c41f69f6d083a9afb5d4234"
-  integrity sha512-w5zsGpNGocL8OHPDDrQzn44QzOtBmCIXOugXqkIhpgO5p1gdPeL2jxQnCca0FT22AMyt8oYcdvzyRgy5rvgdQw==
+"@salesforce/core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@salesforce/core/-/core-2.0.0.tgz#59588d4e66d3c68ad7af4cbcdc74bc45d61093b8"
+  integrity sha512-jNC/w1DAlDo5lSaDCst9fYJiWo74V6Rmc4qrEoWbPXTvjOGe/FvrDrmfVTVI60dkysTNrSJsqNU24XBIkYBdsA==
   dependencies:
     "@salesforce/kit" "^1.0.0"
     "@salesforce/ts-sinon" "^1.0.0"


### PR DESCRIPTION
Core no longer supports overwrite existing auth file with a new config
if an auth file already exits.

BREAKING CHANGE: 🧨 Yes AuthInfo object is not backward compatible.