### PR TITLE
fix: respect SFDX_CONTENT_TYPE=JSON

### DIFF
--- a/packages/command/src/ux.ts
+++ b/packages/command/src/ux.ts
@@ -1,4 +1,6 @@
+import { env } from '@salesforce/kit';
 import { ensure } from '@salesforce/ts-types';
+
 /*
  * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.
@@ -85,8 +87,9 @@ export class UX {
     if (isBoolean(isOutputEnabled)) {
       this.isOutputEnabled = isOutputEnabled;
     } else {
-      // Respect the --json flag for consumers who don't explicitly check
-      this.isOutputEnabled = !process.argv.find(arg => arg === '--json');
+      // Respect the --json flag and SFDX_CONTENT_TYPE for consumers who don't explicitly check
+      const isContentTypeJSON = env.getString('SFDX_CONTENT_TYPE', '').toUpperCase() === 'JSON';
+      this.isOutputEnabled = !(process.argv.find(arg => arg === '--json') || isContentTypeJSON);
     }
   }
 

--- a/packages/command/test/unit/sfdxCommand.test.ts
+++ b/packages/command/test/unit/sfdxCommand.test.ts
@@ -493,24 +493,52 @@ describe('SfdxCommand', () => {
     });
   });
 
-  it('should set this.isJson and only output ux.logJson with the --json flag', async () => {
-    // Run the command
-    class TestCommand extends BaseTestCommand {}
-    const output = await TestCommand.run(['--json']);
-
-    expect(output).to.equal(TestCommand.output);
-    expect(testCommandMeta.cmd.args, 'TestCommand.args should be undefined').to.equal(undefined);
-    verifyCmdFlags({ flag1: { type: 'option' } });
-    verifyInstanceProps({
-      flags: Object.assign({ json: true }, DEFAULT_INSTANCE_PROPS.flags),
-      isJson: true
+  describe('JSON', () => {
+    afterEach(() => {
+      env.unset('SFDX_CONTENT_TYPE');
     });
-    const expectedResult = {
-      data: TestCommand.output,
-      tableColumnData: undefined
-    };
-    expect(testCommandMeta.cmdInstance['result']).to.include(expectedResult);
-    verifyUXOutput({ logJson: [{ status: 0, result: TestCommand.output }] });
+
+    it('should set this.isJson and only output ux.logJson with the --json flag', async () => {
+      // Run the command
+      class TestCommand extends BaseTestCommand {}
+      const output = await TestCommand.run(['--json']);
+
+      expect(output).to.equal(TestCommand.output);
+      expect(testCommandMeta.cmd.args, 'TestCommand.args should be undefined').to.equal(undefined);
+      verifyCmdFlags({ flag1: { type: 'option' } });
+      verifyInstanceProps({
+        flags: Object.assign({ json: true }, DEFAULT_INSTANCE_PROPS.flags),
+        isJson: true
+      });
+      const expectedResult = {
+        data: TestCommand.output,
+        tableColumnData: undefined
+      };
+      expect(testCommandMeta.cmdInstance['result']).to.include(expectedResult);
+      verifyUXOutput({ logJson: [{ status: 0, result: TestCommand.output }] });
+    });
+
+    it('should set this.isJson and only output ux.logJson with SFDX_CONTENT_TYPE=JSON', async () => {
+      // Run the command
+      class TestCommand extends BaseTestCommand {}
+
+      env.setString('SFDX_CONTENT_TYPE', 'Json');
+      const output = await TestCommand.run([]);
+
+      expect(output).to.equal(TestCommand.output);
+      expect(testCommandMeta.cmd.args, 'TestCommand.args should be undefined').to.equal(undefined);
+      verifyCmdFlags({ flag1: { type: 'option' } });
+      verifyInstanceProps({
+        flags: Object.assign({ json: true }, DEFAULT_INSTANCE_PROPS.flags),
+        isJson: true
+      });
+      const expectedResult = {
+        data: TestCommand.output,
+        tableColumnData: undefined
+      };
+      expect(testCommandMeta.cmdInstance['result']).to.include(expectedResult);
+      verifyUXOutput({ logJson: [{ status: 0, result: TestCommand.output }] });
+    });
   });
 
   it('should allow adding information to the returned object for --json', async () => {

--- a/packages/command/test/unit/ux.test.ts
+++ b/packages/command/test/unit/ux.test.ts
@@ -7,6 +7,7 @@
 
 import { Logger } from '@salesforce/core';
 import { testSetup } from '@salesforce/core/lib/testSetup';
+import { env } from '@salesforce/kit';
 import { Dictionary, Optional } from '@salesforce/ts-types';
 import { expect } from 'chai';
 import chalk from 'chalk';
@@ -45,19 +46,39 @@ describe('UX', () => {
     expect(ux1).to.equal(ux);
   });
 
-  it('log() should not log to stdout when json is set via the process args', () => {
-    const info = $$.SANDBOX.stub($$.TEST_LOGGER, 'info');
-    const log = $$.SANDBOX.stub(cli, 'log');
-    process.argv = ['--json'];
-    const ux = new UX($$.TEST_LOGGER, undefined, cli);
-    const logMsg = 'test log() 1 for log wrapper';
+  describe('JSON', () => {
+    afterEach(() => {
+      env.unset('SFDX_CONTENT_TYPE');
+    });
 
-    const ux1 = ux.log(logMsg);
+    it('log() should not log to stdout when json is set via the process args', () => {
+      const info = $$.SANDBOX.stub($$.TEST_LOGGER, 'info');
+      const log = $$.SANDBOX.stub(cli, 'log');
+      process.argv = ['--json'];
+      const ux = new UX($$.TEST_LOGGER, undefined, cli);
+      const logMsg = 'test log() 1 for log wrapper';
 
-    expect(info.called).to.equal(true);
-    expect(info.firstCall.args[0]).to.equal(logMsg);
-    expect(log.called).to.equal(false);
-    expect(ux1).to.equal(ux);
+      const ux1 = ux.log(logMsg);
+
+      expect(info.called).to.equal(true);
+      expect(info.firstCall.args[0]).to.equal(logMsg);
+      expect(log.called).to.equal(false);
+      expect(ux1).to.equal(ux);
+    });
+    it('log() should not log to stdout when SFDX_CONTENT_TYPE=JSON', () => {
+      const info = $$.SANDBOX.stub($$.TEST_LOGGER, 'info');
+      const log = $$.SANDBOX.stub(cli, 'log');
+      env.setString('SFDX_CONTENT_TYPE', 'jSON');
+      const ux = new UX($$.TEST_LOGGER, undefined, cli);
+      const logMsg = 'test log() 1 for log wrapper';
+
+      const ux1 = ux.log(logMsg);
+
+      expect(info.called).to.equal(true);
+      expect(info.firstCall.args[0]).to.equal(logMsg);
+      expect(log.called).to.equal(false);
+      expect(ux1).to.equal(ux);
+    });
   });
 
   it('log() should log to the logger and stdout when output IS enabled', () => {


### PR DESCRIPTION
SfdxCommand and UX don't support the SFDX_CONTENT_TYPE=JSON which should make plugins behave is if the `--json` flag were set. 

https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_cli_json_support.htm

