### PR TITLE
feat: change json errors to stdout

### DIFF
--- a/packages/command/src/sfdxCommand.ts
+++ b/packages/command/src/sfdxCommand.ts
@@ -378,7 +378,7 @@ export abstract class SfdxCommand extends Command {
 
     if (this.isJson) {
       // This should default to true, which will require a major version bump.
-      const sendToStdout = env.getBoolean('SFDX_JSON_TO_STDOUT');
+      const sendToStdout = env.getBoolean('SFDX_JSON_TO_STDOUT', true);
       if (sendToStdout) {
         this.ux.logJson(userDisplayError);
       } else {


### PR DESCRIPTION
BREAKING CHANGE: Moving json errors to stdout instead of stderr may break some tests or scripts
expecting it to be in stderr.

@W-5490315@