### PR TITLE
fix: updates buildArray to handle various comma separated arrangements

### DIFF
--- a/packages/command/src/sfdxFlags.ts
+++ b/packages/command/src/sfdxFlags.ts
@@ -150,7 +150,9 @@ function buildStringArray(kind: flags.Kind, options: flags.Array<string>): flags
   const { options: values, validate, ...rest } = options;
   const allowed = new Set(values);
   return option(kind, rest, val => {
-    const vals = val.split(options.delimiter || ',');
+    const regex = /\"(.*?)\"|\'(.*?)\'|,/g;
+    const vals = val.split(regex).filter(i => !!i);
+
     validateArrayValues(kind, val, vals, options.validate);
     validateArrayOptions(kind, val, vals, allowed);
     return vals;
@@ -160,17 +162,13 @@ function buildStringArray(kind: flags.Kind, options: flags.Array<string>): flags
 function buildMappedArray<T>(kind: flags.Kind, options: flags.MappedArray<T>): flags.Discriminated<flags.Array<T>> {
   const { options: values, validate, ...rest } = options;
   const allowed = new Set(values);
-  return option(
-    kind,
-    rest,
-    (val: string): T[] => {
-      const vals = val.split(options.delimiter || ',');
-      validateArrayValues(kind, val, vals, options.validate);
-      const mappedVals = vals.map(options.map);
-      validateArrayOptions(kind, val, mappedVals, allowed);
-      return mappedVals;
-    }
-  );
+  return option(kind, rest, (val: string): T[] => {
+    const vals = val.split(options.delimiter || ',');
+    validateArrayValues(kind, val, vals, options.validate);
+    const mappedVals = vals.map(options.map);
+    validateArrayOptions(kind, val, mappedVals, allowed);
+    return mappedVals;
+  });
 }
 
 function buildDate(options: flags.DateTime): flags.Discriminated<flags.DateTime> {

--- a/packages/command/test/unit/sfdxFlags.test.ts
+++ b/packages/command/test/unit/sfdxFlags.test.ts
@@ -353,6 +353,19 @@ describe('SfdxFlags', () => {
           'The flag value "1,2,c" is not in the correct format for "array." Must only contain valid values.'
         );
       });
+
+      it('should handle various arrangments of comma separated lists without errors', () => {
+        const array = flags.array({ description: 'test' });
+        if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
+        expect(array.parse('"1, 2, 3, 4, 5, 6"')).to.deep.equal(['1, 2, 3, 4, 5, 6']);
+        expect(array.parse('1,2,3,4,5,6')).to.deep.equal(['1', '2', '3', '4', '5', '6']);
+        expect(array.parse('"1, 2","3, 4","5, 6"')).to.deep.equal(['1, 2', '3, 4', '5, 6']);
+        expect(array.parse('1,"2, 3","4, 5",6')).to.deep.equal(['1', '2, 3', '4, 5', '6']);
+        expect(array.parse('"1, 2",3,4,"5, 6"')).to.deep.equal(['1, 2', '3', '4', '5, 6']);
+        expect(array.parse("'1,2','3,4','5,6'")).to.deep.equal(['1,2', '3,4', '5,6']);
+        expect(array.parse("'1,2',3,4,'5,6'")).to.deep.equal(['1,2', '3', '4', '5,6']);
+        expect(array.parse("1,'2, 3','4, 5',6")).to.deep.equal(['1', '2, 3', '4, 5', '6']);
+      });
     });
 
     describe('usage', () => {


### PR DESCRIPTION
**What does this PR do?**
There is an existing bug when users attempt to add a comma-separated list to a `mdapi:retrieve --packagenames` command. 
IF the user adds a name that includes a comma. For example: "My new package, title"
The buildArray will split the value into 2 separate strings: 'My new package', 'title'. This will cause that package name to not be found in the user's org. 

This PR adds a new regex for the .split that is being run that will account for quotes that include a comma in the string. It will also account for double or single quotes. 

**Acceptance Criteria**
Users will be able to pass in various iterations of double/single quote separated values with or without commas in between those quotes. 

ex: 
// '1, 2, 3, 4, 5, 6'
// '"1, 2", "3, 4", "5, 6"'
// '1,"2, 3","4, 5", 6'
// '"1, 2", 3,4, "5, 6"'
// "'1,2','3,4','5,6'"
// "'1,2', 3, 4,'5,6'"
// "1,'2, 3','4, 5', 6"
// '1', '2', '3', '4', '5', '6'

All tests should still pass. 

**Testing Notes**
Run `yarn test` and they should still pass