### PR TITLE
feat: array flags trim whitespace

### DIFF
--- a/packages/command/src/sfdxFlags.ts
+++ b/packages/command/src/sfdxFlags.ts
@@ -214,7 +214,7 @@ function buildMappedArray<T>(kind: flags.Kind, options: flags.MappedArray<T>): f
   const { options: values, ...rest } = options;
   const allowed = new Set(values);
   return option(kind, rest, (val: string): T[] => {
-    const vals = val.split(options.delimiter || ',');
+    const vals = val.split(options.delimiter || ',').map((value) => value.trim());
     validateArrayValues(kind, val, vals, options.validate);
     const mappedVals = vals.map(options.map);
     validateArrayOptions(kind, val, mappedVals, allowed);
@@ -228,7 +228,10 @@ function buildStringArray(kind: flags.Kind, options: flags.Array<string>): flags
   return option(kind, rest, (val) => {
     // eslint-disable-next-line no-useless-escape
     const regex = /\"(.*?)\"|\'(.*?)\'|,/g;
-    const vals = val.split(regex).filter((i) => !!i);
+    const vals = val
+      .split(regex)
+      .filter((i) => !!i)
+      .map((i) => i.trim());
 
     validateArrayValues(kind, val, vals, options.validate);
     validateArrayOptions(kind, val, vals, allowed);

--- a/packages/command/test/unit/sfdxFlags.test.ts
+++ b/packages/command/test/unit/sfdxFlags.test.ts
@@ -373,6 +373,20 @@ describe('SfdxFlags', () => {
         expect(array.parse("'1,2',3,4,'5,6'")).to.deep.equal(['1,2', '3', '4', '5,6']);
         expect(array.parse("1,'2, 3','4, 5',6")).to.deep.equal(['1', '2, 3', '4, 5', '6']);
       });
+
+      it('should strip whitespace from parsed array members', () => {
+        const array = flags.array({ description: 'test' });
+        if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
+        expect(array.parse('1, 2, 3, 4, 5')).to.deep.equal(['1', '2', '3', '4', '5']);
+        expect(array.parse('1 ,2 ,3 ,4 ,5')).to.deep.equal(['1', '2', '3', '4', '5']);
+      });
+
+      it('should strip whitespace from parsed mapped string array members', () => {
+        const array = flags.array({ description: 'test', map: (v: string) => `${v}x` });
+        if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
+        expect(array.parse('1, 2, 3, 4, 5')).to.deep.equal(['1x', '2x', '3x', '4x', '5x']);
+        expect(array.parse('1 ,2 ,3 ,4 ,5')).to.deep.equal(['1x', '2x', '3x', '4x', '5x']);
+      });
     });
 
     describe('usage', () => {


### PR DESCRIPTION
per discussion with @amphro yesterday.

makes sfdxFlags friendlier so developers don't have to do this:
https://github.com/salesforcecli/plugin-user/blob/a01e5a9d57ce5b88f0f6a06dc441a72bf6225c25/src/commands/force/user/permset/assign.ts#L53

