### PR TITLE
Sm/arrays delimiter testing

### DIFF
--- a/packages/command/src/sfdxFlags.ts
+++ b/packages/command/src/sfdxFlags.ts
@@ -214,7 +214,7 @@ function buildMappedArray<T>(kind: flags.Kind, options: flags.MappedArray<T>): f
   const { options: values, ...rest } = options;
   const allowed = new Set(values);
   return option(kind, rest, (val: string): T[] => {
-    const vals = val.split(options.delimiter || ',');
+    const vals = val.split(options.delimiter || ',').map((value) => value.trim());
     validateArrayValues(kind, val, vals, options.validate);
     const mappedVals = vals.map(options.map);
     validateArrayOptions(kind, val, mappedVals, allowed);
@@ -228,7 +228,10 @@ function buildStringArray(kind: flags.Kind, options: flags.Array<string>): flags
   return option(kind, rest, (val) => {
     // eslint-disable-next-line no-useless-escape
     const regex = /\"(.*?)\"|\'(.*?)\'|,/g;
-    const vals = val.split(regex).filter((i) => !!i);
+    const vals = val
+      .split(regex)
+      .filter((i) => !!i)
+      .map((i) => i.trim());
 
     validateArrayValues(kind, val, vals, options.validate);
     validateArrayOptions(kind, val, vals, allowed);

--- a/packages/command/test/unit/sfdxFlags.test.ts
+++ b/packages/command/test/unit/sfdxFlags.test.ts
@@ -373,6 +373,20 @@ describe('SfdxFlags', () => {
         expect(array.parse("'1,2',3,4,'5,6'")).to.deep.equal(['1,2', '3', '4', '5,6']);
         expect(array.parse("1,'2, 3','4, 5',6")).to.deep.equal(['1', '2, 3', '4, 5', '6']);
       });
+
+      it('should strip whitespace from parsed array members', () => {
+        const array = flags.array({ description: 'test' });
+        if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
+        expect(array.parse('1, 2, 3, 4, 5')).to.deep.equal(['1', '2', '3', '4', '5']);
+        expect(array.parse('1 ,2 ,3 ,4 ,5')).to.deep.equal(['1', '2', '3', '4', '5']);
+      });
+
+      it('should strip whitespace from parsed mapped string array members', () => {
+        const array = flags.array({ description: 'test', map: (v: string) => `${v}x` });
+        if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
+        expect(array.parse('1, 2, 3, 4, 5')).to.deep.equal(['1x', '2x', '3x', '4x', '5x']);
+        expect(array.parse('1 ,2 ,3 ,4 ,5')).to.deep.equal(['1x', '2x', '3x', '4x', '5x']);
+      });
     });
 
     describe('usage', () => {

--- a/packages/command/test/unit/sfdxFlags.test.ts
+++ b/packages/command/test/unit/sfdxFlags.test.ts
@@ -361,7 +361,7 @@ describe('SfdxFlags', () => {
         );
       });
 
-      it('should handle various arrangments of comma separated lists without errors', () => {
+      it('should handle various arrangements of comma separated lists without errors', () => {
         const array = flags.array({ description: 'test' });
         if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
         expect(array.parse('"1, 2, 3, 4, 5, 6"')).to.deep.equal(['1, 2, 3, 4, 5, 6']);
@@ -372,6 +372,18 @@ describe('SfdxFlags', () => {
         expect(array.parse("'1,2','3,4','5,6'")).to.deep.equal(['1,2', '3,4', '5,6']);
         expect(array.parse("'1,2',3,4,'5,6'")).to.deep.equal(['1,2', '3', '4', '5,6']);
         expect(array.parse("1,'2, 3','4, 5',6")).to.deep.equal(['1', '2, 3', '4, 5', '6']);
+      });
+
+      it('should handle custom delimiter', () => {
+        const array = flags.array({ description: 'test', delimiter: ';' });
+        if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
+        expect(array.parse('1;2;3;4;5')).to.deep.equal(['1', '2', '3', '4', '5']);
+      });
+
+      it('should handle custom delimiter with mappedArray', () => {
+        const array = flags.array({ description: 'test', delimiter: ';', map: (v: string) => `${v}x` });
+        if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
+        expect(array.parse('1;2;3;4;5')).to.deep.equal(['1x', '2x', '3x', '4x', '5x']);
       });
 
       it('should strip whitespace from parsed array members', () => {
@@ -386,6 +398,18 @@ describe('SfdxFlags', () => {
         if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
         expect(array.parse('1, 2, 3, 4, 5')).to.deep.equal(['1x', '2x', '3x', '4x', '5x']);
         expect(array.parse('1 ,2 ,3 ,4 ,5')).to.deep.equal(['1x', '2x', '3x', '4x', '5x']);
+      });
+
+      it('should handle custom delimiter and whitespace', () => {
+        const array = flags.array({ description: 'test', delimiter: ';' });
+        if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
+        expect(array.parse('1; 2; 3; 4; 5')).to.deep.equal(['1', '2', '3', '4', '5']);
+      });
+
+      it('should handle custom delimiter with mappedArray and whitespace', () => {
+        const array = flags.array({ description: 'test', delimiter: ';', map: (v: string) => `${v}x` });
+        if (!hasFunction(array, 'parse')) throw new MissingPropertyError('parse', 'array');
+        expect(array.parse('1; 2; 3; 4; 5')).to.deep.equal(['1x', '2x', '3x', '4x', '5x']);
       });
     });
 


### PR DESCRIPTION
Moved the flag to array conversion to a common function used by both string and mapped Array.   Now any future tweaks cover both paths.

wrote tests for custom delimiters (@peternhale 's original request) across various combinations with other array options.

[this PR includes everything from https://github.com/forcedotcom/cli-packages/pull/138